### PR TITLE
Removed duplicate button on monster selection screen

### DIFF
--- a/code/bbs/src/components/MonsterSelection/MonsterSelectionScreen.tsx
+++ b/code/bbs/src/components/MonsterSelection/MonsterSelectionScreen.tsx
@@ -107,14 +107,6 @@ export const MonsterSelectionScreen: React.FC<MonsterSelectionScreenProps> = ({
           );
         })}
 
-        <button
-          className="glb-btn"
-          id="monster-selection-btn"
-          onClick={handleConfirm}
-          disabled={!confirmEnabled}
-        >
-          Confirm
-        </button>
       </div>
 
       <button


### PR DESCRIPTION
- Simple fix to remove duplicate button